### PR TITLE
Update conflict resolution code

### DIFF
--- a/KitchenCore/Source/Models/Recipe+CloudKit.swift
+++ b/KitchenCore/Source/Models/Recipe+CloudKit.swift
@@ -114,17 +114,17 @@ extension CKAsset {
 
 extension Recipe {
     static func resolveConflict(clientRecord: CKRecord, serverRecord: CKRecord) -> CKRecord? {
-        // Most recent record wins. This might not be the best solution but YOLO.
+        // Custom logic for resolving conflicts.
+        // In this example, the client values will always overwrite all server values.
+        //
+        // The server record has the latest changeTag and must be returned.
 
-        guard let clientDate = clientRecord.modificationDate, let serverDate = serverRecord.modificationDate else {
-            return clientRecord
+        // Merge all client record keys/values into the server record
+        for key in clientRecord.allKeys() {
+            serverRecord[key] = clientRecord[key]
         }
 
-        if clientDate > serverDate {
-            return clientRecord
-        } else {
-            return serverRecord
-        }
+        return serverRecord
     }
 }
 

--- a/KitchenCore/Source/Storage/SyncEngine.swift
+++ b/KitchenCore/Source/Storage/SyncEngine.swift
@@ -328,7 +328,7 @@ final class SyncEngine {
             }
         }
 
-        operation.savePolicy = .changedKeys
+        operation.savePolicy = .ifServerRecordUnchanged
         operation.qualityOfService = .userInitiated
         operation.database = privateDatabase
 


### PR DESCRIPTION
I've updated the conflict resolution code to serve as a better example.

In the previous version, it returned the clientRecord, which is never a valid solution. Only the serverRecord has the recordChangeTag set. Conflicts must be resolved by updating the serverRecord and returning that object, see: https://developer.apple.com/documentation/cloudkit/ckerror/2325208-serverrecordchanged

Modifications in Recipe+CloudKit, resolveConflict:
- Always return serverRecord, never clientRecord
- Don't use clientRecord.modifiedDate, it is always nil for locally created CKRecords
- Merge client keys/values into server record, as a way to "resolve" conflicts

Modifications in SyncEngine:
- Changed CKModifyRecordsOperation.savePolicy from `.changedKeys` to `.ifServerRecordUnchanged`.  
 The previous `.changedKeys` would always overwrite the server version with the client version, therefor no conflicts would ever occur. The default is `.ifServerRecordUnchanged`, and this can trigger conflicts.